### PR TITLE
Bump PyTorch to >=2.6 (security hotfix)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - numpy
   - pandas<3
   - python=3.11
-  - pytorch
+  - pytorch>=2.6
   - pytorch-cuda=12.4
   - pyturbojpeg
   - scikit-learn

--- a/environment_CI.yml
+++ b/environment_CI.yml
@@ -21,7 +21,7 @@ dependencies:
   - numpy
   - pandas<3
   - python=3.11
-  - pytorch
+  - pytorch>=2.6
   - pytest
   - pytest-asyncio>=0.23.0
   - pyturbojpeg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "scikit-image",
     "fitsbolt>=0.1.6",
     "toml",
-    "torch",
+    "torch>=2.6",
     "torchvision",
     "tqdm",
     "zarr>=3.0.0b0",


### PR DESCRIPTION
## Summary
- Bumps minimum PyTorch version to `>=2.6` in `environment.yml`, `environment_CI.yml`, and `pyproject.toml`
- Addresses security vulnerability [GHSA-53q9-r3pm-6pq6](https://github.com/pytorch/pytorch/security/advisories/GHSA-53q9-r3pm-6pq6)

## Test plan
- [x] CI pipeline passes with the new version constraint