### PR TITLE
fix(env): use conda-forge pytorch-gpu for reliable CUDA builds

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,6 @@
 #   the terms contained in the file 'LICENCE.txt'.
 name: am
 channels:
-  - pytorch
-  - nvidia
   - conda-forge
 dependencies:
   - astropy
@@ -23,7 +21,7 @@ dependencies:
   - pyarrow
   - python=3.11
   - pytorch>=2.6
-  - pytorch-cuda=12.4
+  - pytorch-gpu
   - pyturbojpeg
   - scikit-image
   - scikit-learn


### PR DESCRIPTION
## Summary

- Remove `pytorch` and `nvidia` channels — use only `conda-forge`
- Replace `pytorch-cuda=12.4` with `pytorch-gpu` (conda-forge meta-package)

## Why

The `pytorch-cuda` package from the pytorch channel does not constrain the `pytorch` package to its GPU variant. The conda solver can satisfy both `pytorch>=2.6` and `pytorch-cuda=12.4` by installing CPU pytorch from conda-forge alongside pytorch-cuda from the pytorch channel.

The conda-forge `pytorch-gpu` meta-package correctly forces the CUDA variant of pytorch to be installed.

## Test plan

- [x] `CONDA_OVERRIDE_CUDA="12" mamba env create -f environment.yml` installs pytorch with `cuda*` build string
- [x] `python -c "import torch; print(torch.cuda.is_available())"` returns `True` on GPU node