### PR TITLE
feat: add trusted legacy checkpoint conversion utility

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,6 +13,7 @@
 
 ### Changed
 - **Security:** replaced pickle-based `torch.save` / `torch.load` checkpointing with `safetensors`, removing the pickle deserialisation risk on untrusted model files (#9)
+- Added an explicit, trust-gated utility for converting legacy `.pth`/`.pkl` checkpoints to `.safetensors`
 - **PyTorch minimum** raised to `>=2.6` in the conda environments to pick up upstream CVE fixes (#11)
 - **Cutana minimum** raised to `>=0.3.0` in `environment.yml`, `environment_CI.yml`, and `pyproject.toml`
 

--- a/README.md
+++ b/README.md
@@ -111,11 +111,19 @@ session_name_timestamp/
     └── ...
 ```
 
-**Model checkpoint format (since v1.3.1):** Checkpoints are saved as `.safetensors` (secure — no pickle-based code execution) instead of `.pth`. Checkpoints written by older versions (`.pth`/`.pkl`) **cannot** be loaded by the current code and fail with `SafetensorError: Error while deserializing header`. Re-train the model with the current version to obtain a `.safetensors` checkpoint. To instead keep using an existing `.pth` model, install the last pre-safetensors release (`v1.3.0`):
+**Model checkpoint format (since v1.3.1):** Checkpoints are saved and loaded as `.safetensors` (secure — no pickle-based code execution). Checkpoints written by older versions (`.pth`/`.pkl`) are not loaded directly by the application.
+
+### Converting legacy checkpoints
+
+If you have a legacy checkpoint created by a trusted older AnomalyMatch version, convert it once:
 
 ```bash
-pip install "git+https://github.com/esa/AnomalyMatch.git@v1.3.0"
+python scripts/convert_legacy_checkpoint.py path/to/model.pth --trusted
 ```
+
+This writes `path/to/model.safetensors`, which can then be used as `model_path`. Use `--output` to choose another destination.
+
+Only run this command on checkpoints you trust. Legacy PyTorch/pickle checkpoints can execute arbitrary code when loaded.
 
 **Iteration Scores:** After each training iteration, AnomalyMatch stores prediction scores for both unlabelled and test data (if `test_ratio > 0`). These CSV files contain filenames and their corresponding anomaly scores, enabling analysis of how predictions evolve across training iterations.
 

--- a/anomaly_match/data_io/checkpoint_io.py
+++ b/anomaly_match/data_io/checkpoint_io.py
@@ -22,6 +22,7 @@ Checkpoint layout inside a single ``.safetensors`` file:
 from __future__ import annotations
 
 import json
+import pickle
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -232,6 +233,17 @@ def save_checkpoint(save_state: dict[str, Any], path: str | Path) -> Path:
     return path
 
 
+def _load_trusted_legacy_checkpoint(path: Path, map_location: str) -> dict[str, Any]:
+    if path.suffix.lower() == ".pkl":
+        try:
+            with path.open("rb") as file:
+                return pickle.load(file)
+        except (pickle.UnpicklingError, EOFError):
+            pass
+
+    return torch.load(path, map_location=map_location, weights_only=False)
+
+
 def convert_legacy_checkpoint_to_safetensors(
     legacy_path: str | Path,
     output_path: str | Path | None = None,
@@ -259,7 +271,7 @@ def convert_legacy_checkpoint_to_safetensors(
     if not legacy_path.is_file():
         raise FileNotFoundError(f"Legacy checkpoint not found: {legacy_path}")
 
-    checkpoint = torch.load(legacy_path, map_location=map_location, weights_only=False)
+    checkpoint = _load_trusted_legacy_checkpoint(legacy_path, map_location)
     if not isinstance(checkpoint, dict):
         raise ValueError("Legacy checkpoint must contain a checkpoint dictionary.")
     for model_key in ("train_model", "eval_model"):

--- a/anomaly_match/data_io/checkpoint_io.py
+++ b/anomaly_match/data_io/checkpoint_io.py
@@ -232,6 +232,48 @@ def save_checkpoint(save_state: dict[str, Any], path: str | Path) -> Path:
     return path
 
 
+def convert_legacy_checkpoint_to_safetensors(
+    legacy_path: str | Path,
+    output_path: str | Path | None = None,
+    *,
+    trusted: bool = False,
+    map_location: str = "cpu",
+) -> Path:
+    """Convert one trusted pickle-based checkpoint to ``.safetensors``.
+
+    This deliberately unsafe deserialization is isolated from normal checkpoint
+    loading and must be explicitly enabled for each conversion.
+    """
+    if not trusted:
+        raise ValueError(
+            "Conversion requires trusted=True. Legacy PyTorch/pickle checkpoints "
+            "can execute arbitrary code when loaded; only convert files from trusted sources."
+        )
+
+    legacy_path = Path(legacy_path)
+    if legacy_path.suffix.lower() not in {".pth", ".pkl"}:
+        raise ValueError(
+            f"Unsupported legacy checkpoint extension {legacy_path.suffix!r}; "
+            "expected .pth or .pkl."
+        )
+    if not legacy_path.is_file():
+        raise FileNotFoundError(f"Legacy checkpoint not found: {legacy_path}")
+
+    checkpoint = torch.load(legacy_path, map_location=map_location, weights_only=False)
+    if not isinstance(checkpoint, dict):
+        raise ValueError("Legacy checkpoint must contain a checkpoint dictionary.")
+    for model_key in ("train_model", "eval_model"):
+        state_dict = checkpoint.get(model_key)
+        if not isinstance(state_dict, dict) or not all(
+            isinstance(value, torch.Tensor) for value in state_dict.values()
+        ):
+            raise ValueError(
+                f"Legacy checkpoint key {model_key!r} must contain a tensor state dictionary."
+            )
+
+    return save_checkpoint(checkpoint, output_path or legacy_path.with_suffix(".safetensors"))
+
+
 def load_checkpoint(path: str | Path, device: str = "cpu") -> dict[str, Any]:
     """Load a model checkpoint from a ``.safetensors`` file.
 

--- a/scripts/convert_legacy_checkpoint.py
+++ b/scripts/convert_legacy_checkpoint.py
@@ -1,0 +1,37 @@
+#   Copyright (c) European Space Agency, 2025.
+#
+#   This file is subject to the terms and conditions defined in file 'LICENCE.txt', which
+#   is part of this source code package. No part of the package, including
+#   this file, may be copied, modified, propagated, or distributed except according to
+#   the terms contained in the file 'LICENCE.txt'.
+
+"""Convert a trusted legacy AnomalyMatch checkpoint to safetensors."""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from anomaly_match.data_io.checkpoint_io import convert_legacy_checkpoint_to_safetensors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("legacy_path", help="Trusted .pth or .pkl checkpoint")
+    parser.add_argument("--output", help="Output path (the suffix is forced to .safetensors)")
+    parser.add_argument(
+        "--trusted",
+        action="store_true",
+        required=True,
+        help="Confirm the checkpoint is trusted despite pickle's arbitrary-code risk",
+    )
+    args = parser.parse_args()
+
+    output = convert_legacy_checkpoint_to_safetensors(
+        args.legacy_path, args.output, trusted=args.trusted
+    )
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_checkpoint_io.py
+++ b/tests/unit/test_checkpoint_io.py
@@ -8,6 +8,7 @@
 """Unit tests for checkpoint_io: safetensors-based model checkpoint serialization."""
 
 import json
+import pickle
 
 import numpy as np
 import pytest
@@ -244,6 +245,21 @@ class TestLegacyConversion:
         assert torch.equal(loaded["train_model"]["weight"], original["train_model"]["weight"])
         assert loaded["it"] == original["it"]
 
+    def test_converts_plain_pickle_checkpoint(self, tmp_path):
+        original = _make_full_checkpoint()
+        legacy_path = tmp_path / "model.pkl"
+        with legacy_path.open("wb") as file:
+            pickle.dump(original, file)
+
+        output = convert_legacy_checkpoint_to_safetensors(legacy_path, trusted=True)
+        loaded = load_checkpoint(output)
+
+        assert loaded["it"] == original["it"]
+        assert torch.equal(
+            loaded["train_model"]["layer.weight"],
+            original["train_model"]["layer.weight"],
+        )
+
     def test_requires_trusted_before_loading(self, tmp_path, monkeypatch):
         legacy_path = tmp_path / "model.pth"
         legacy_path.touch()
@@ -271,7 +287,7 @@ class TestLegacyConversion:
         with pytest.raises(ValueError, match="checkpoint dictionary"):
             convert_legacy_checkpoint_to_safetensors(legacy_path, trusted=True)
 
-    def test_respects_explicit_output_and_forces_suffix(self, tmp_path):
+    def test_converts_torch_saved_pkl_and_respects_output(self, tmp_path):
         legacy_path = tmp_path / "model.pkl"
         torch.save(_make_full_checkpoint(), legacy_path)
 

--- a/tests/unit/test_checkpoint_io.py
+++ b/tests/unit/test_checkpoint_io.py
@@ -16,7 +16,11 @@ from dotmap import DotMap
 from fitsbolt.normalisation.NormalisationMethod import NormalisationMethod
 from safetensors import safe_open
 
-from anomaly_match.data_io.checkpoint_io import load_checkpoint, save_checkpoint
+from anomaly_match.data_io.checkpoint_io import (
+    convert_legacy_checkpoint_to_safetensors,
+    load_checkpoint,
+    save_checkpoint,
+)
 
 
 def _make_state_dict(seed=0):
@@ -215,6 +219,68 @@ class TestFileFormat:
         loaded = load_checkpoint(path)
         assert "train_model" in loaded
         assert "eval_model" in loaded
+
+
+class TestLegacyConversion:
+    def test_converts_checkpoint(self, tmp_path):
+        model = torch.nn.Linear(3, 2)
+        optimizer = torch.optim.Adam(model.parameters())
+        model(torch.randn(1, 3)).sum().backward()
+        optimizer.step()
+        original = _make_full_checkpoint(
+            train_model=model.state_dict(),
+            eval_model=model.state_dict(),
+            optimizer=optimizer.state_dict(),
+        )
+        legacy_path = tmp_path / "model.pth"
+        torch.save(original, legacy_path)
+
+        output = convert_legacy_checkpoint_to_safetensors(legacy_path, trusted=True)
+        loaded = load_checkpoint(output)
+
+        assert output == tmp_path / "model.safetensors"
+        assert output.exists()
+        assert loaded.keys() == original.keys()
+        assert torch.equal(loaded["train_model"]["weight"], original["train_model"]["weight"])
+        assert loaded["it"] == original["it"]
+
+    def test_requires_trusted_before_loading(self, tmp_path, monkeypatch):
+        legacy_path = tmp_path / "model.pth"
+        legacy_path.touch()
+
+        def fail_if_called(*args, **kwargs):
+            pytest.fail("torch.load must not be called without explicit trust")
+
+        monkeypatch.setattr(torch, "load", fail_if_called)
+        with pytest.raises(ValueError, match="arbitrary code"):
+            convert_legacy_checkpoint_to_safetensors(legacy_path)
+
+    def test_rejects_unsupported_extension(self, tmp_path):
+        path = tmp_path / "model.txt"
+        path.touch()
+        with pytest.raises(ValueError, match=r"expected \.pth or \.pkl"):
+            convert_legacy_checkpoint_to_safetensors(path, trusted=True)
+
+    def test_rejects_missing_file(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="Legacy checkpoint not found"):
+            convert_legacy_checkpoint_to_safetensors(tmp_path / "missing.pth", trusted=True)
+
+    def test_rejects_non_dictionary_checkpoint(self, tmp_path):
+        legacy_path = tmp_path / "model.pth"
+        torch.save(["not", "a", "checkpoint"], legacy_path)
+        with pytest.raises(ValueError, match="checkpoint dictionary"):
+            convert_legacy_checkpoint_to_safetensors(legacy_path, trusted=True)
+
+    def test_respects_explicit_output_and_forces_suffix(self, tmp_path):
+        legacy_path = tmp_path / "model.pkl"
+        torch.save(_make_full_checkpoint(), legacy_path)
+
+        output = convert_legacy_checkpoint_to_safetensors(
+            legacy_path, tmp_path / "converted.pth", trusted=True
+        )
+
+        assert output == tmp_path / "converted.safetensors"
+        assert output.exists()
 
 
 class TestSecurity:


### PR DESCRIPTION
Hi,

While exploring the codebase, I noticed a small migration gap for users with legacy checkpoints created before the move to `.safetensors`. This PR adds an explicit conversion utility while keeping the runtime loading path unchanged.

## Summary

- Add a utility to convert trusted legacy `.pth` / `.pkl` checkpoints to `.safetensors`
- Keep normal checkpoint loading `.safetensors`-only
- Document the security model and migration path for pre-v1.3.1 checkpoints

## Security

Legacy checkpoint conversion requires an explicit `--trusted` flag because PyTorch / pickle deserialization can execute arbitrary code. This PR does not reintroduce automatic `.pth` / `.pkl` loading into the runtime model-loading path.

## Tests

- Add tests for successful conversion
- Add tests for refusal without the trust flag
- Add tests for missing files
- Add tests for unsupported extensions
- Add tests for output path behavior